### PR TITLE
Minishell Release Ver_1.0.1 !!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SRCS += signal_util.c export_util.c
 OBJS = $(SRCS:.c=.o)
 
 ## compile
-CC=	gcc
+CC=	cc
 CFLAGS = -Wall -Wextra -Werror $(addprefix -I,$(INC_DIRS))
 LDFLAGS= $(addprefix -L,$(LIB_DIRS)) -lreadline -lft
 

--- a/execute/exec_redirect.c
+++ b/execute/exec_redirect.c
@@ -10,6 +10,8 @@ void	exec_input(t_node *node, t_context *p_ctx)
 	rhs = node->right;
 	if (p_ctx->fd[STDIN] != STDIN)
 		close(p_ctx->fd[STDIN]);
+	if (p_ctx->fd[STDIN] != STDIN)
+		close(p_ctx->fd[STDIN]);
 	if (ambiguity_check(&filename, p_ctx, rhs))
 		return ;
 	if (!is_regular_file(filename[0], p_ctx) || \
@@ -32,6 +34,8 @@ void	exec_output(t_node *node, t_context *p_ctx)
 
 	lhs = node->left;
 	rhs = node->right;
+	if (p_ctx->fd[STDIN] != STDIN)
+		close(p_ctx->fd[STDIN]);
 	if (p_ctx->fd[STDOUT] != STDOUT)
 		close(p_ctx->fd[STDOUT]);
 	if (ambiguity_check(&filename, p_ctx, rhs))
@@ -57,6 +61,9 @@ void	exec_append(t_node *node, t_context *p_ctx)
 
 	lhs = node->left;
 	rhs = node->right;
+
+	if (p_ctx->fd[STDIN] != STDIN)
+		close(p_ctx->fd[STDIN]);
 	if (p_ctx->fd[STDOUT] != STDOUT)
 		close(p_ctx->fd[STDOUT]);
 	if (ambiguity_check(&filename, p_ctx, rhs))

--- a/execute/exec_redirect_util.c
+++ b/execute/exec_redirect_util.c
@@ -48,7 +48,7 @@ t_bool	is_not_directory(char *filename, t_context *p_ctx)
 
 t_bool	check_permission(char *filename, t_context *p_ctx, int mode_bit)
 {
-	if (access(filename, mode_bit) != 0)
+	if (access(filename, F_OK) == 0 && access(filename, mode_bit) != 0)
 	{
 		msh_error(filename, NULL, EACCES);
 		p_ctx->exit_status = 1;

--- a/execute/exec_word.c
+++ b/execute/exec_word.c
@@ -35,10 +35,13 @@ void	fork_exec(char **argv, t_context *p_ctx)
 		sigact_modeoff();
 		dup2(p_ctx->fd[STDIN], STDIN);
 		dup2(p_ctx->fd[STDOUT], STDOUT);
-		if (p_ctx->fd_close >= 0)
+		if (p_ctx->fd_close > 0)
 			close(p_ctx->fd_close);
+		if (p_ctx->fd[STDIN] != STDIN)
+			close(p_ctx->fd[STDIN]);
+		if (p_ctx->fd[STDOUT] != STDOUT)
+			close(p_ctx->fd[STDOUT]);
 		execve(argv[0], argv, list_to_arr(envl));
-		exit(1);
 	}
 	if (p_ctx->fd[STDIN] != STDIN)
 		close(p_ctx->fd[STDIN]);


### PR DESCRIPTION
# 중요 업데이트 사항

1. readme 파일을 추가하였습니다 ! 이제부터는 정식 배포판입니다 !!

2. 파일권한이 없던 파일을 리다이렉트(< , > , >>)하는 경우에 대한 처리를 추가하였습니다.

3. 입력 파일을 제대로 읽을 수 없는 상황((is_not_regular && permission deny)인 프로세스가 파이프 통신을 할 때 출력을 받는 프로세스가 sigpipe를 받지 못해 무한입력대기를 하는 버그를 수정하였습니다.

    -ex) ls < 내문서(디렉토리인 경우) | cat

4. 빌트인 함수 ft_cd의 기능과 버그를 수정하였습니다

	4-1. 출력문 방식 일부 수정
	ex) cd
	-> HOME 환경변수가 존재하지 않는 경우, cd : Home not set이라는 문구가 뜨게끔 수정하였습니다.

	4-2. 경로 인자가 여러개 들어올 경우 가장 첫번째 경로만 취급하게끔 기능 수정
	ex) cd .. asdasd && ls
	-> 이전 ft_cd는 경로인자가 여러 개 들어왔을 때 항상 명령실패로 간주하고 종료코드가 1이 되었지만 이젠 가장 첫번째 주소의 경로를 기준으로 종료코드를 판단합니다.
	
	4-3. 세그폴트 관련 이슈 해결
	ex) cd test/1/2/3 (3번 폴더로 이동) -> rm -rf test/* (현재 경로의 폴더를 삭제) ->  cd .. (세그폴트 발생)
	-> 이제는 삭제된 폴더에 cd를 하더라도 정상적으로 처리 됩니다. 
	==> 이슈 원인은 ft_cd()에서 삭제된 경로의 폴더로 chdir()하더라도 이상하게 chdir()함수는 성공을 반환하고 있습니다. 따라서 chdir()가 실패했을 때의 if문 코드로 진입하지 못하고 계속 코드가 동작하게 되어 세그폴트가 발생하고 있었습니다.

5. 빌트인 함수 ft_export 기능을 수정하였습니다

	5-1. export에서 설정하는 쉘 변수의 이름들이 Variable naming conventions을 준수하도록 수정하였습니다.

	5-2. 쉘변수에 등록은 되었지만 값이 초기화되어 있지 않던 쉘 변수들이 export 호출시 표시되지 않던 버그를 수정하였습니다.

6. permission_check() 함수에 에러가 있어서 수정했습니다.

# 기타 업데이트 사항

1. 히어독에서 컨트롤+C (인터럽트) 종료시 종료코드가 1이 되도록 수정했습니다.

2. 파이프 프로세스를 호출 할 때, dup2()호출 이후 쓸모 없어진 파일디스크럽터를 삭제해주지 않던 부분을 수정했습니다.

# Develop Announce

초기화되어 있지 않은 쉘 변수를 확장하여 실행할 때 기존 bash는 개행처리가 된 것처럼 진행되나, 현재 우리 쉘은 bash : "" (command not found) 로 처리되고 있음.

해당 부분은 스타일 차이라 굳이 바꾸지 않아도 될 것 같아 수정에 대해서는 고민중.
